### PR TITLE
Tweak citation

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -73,7 +73,7 @@ identify reasons for lack of fit of a process to data.
 
 Though there are some existing 
 packages that contain functions for simulating point 
-processes, [@hawkes_14],[@Markov_17],
+processes, [@hawkes_14; @Markov_17],
 and for computing some 
 simple residuals [@PtProcess2010],
 to the best of our knowledge, 


### PR DESCRIPTION
This is part of openjournals/joss-reviews#3133

Minor tweak to the double citation to match the preferred [citation syntax](https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#Citation_Syntax).